### PR TITLE
docs: polish README for better first impression

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,23 @@
 [![Stars](https://img.shields.io/github/stars/qkitzero/github-contribution-growth-graph?style=social)](https://github.com/qkitzero/github-contribution-growth-graph/stargazers)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/qkitzero/github-contribution-growth-graph/pulls)
 
-Visualize your GitHub contribution journey and language usage over multiple years at a glance.
+GitHub's contribution graph shows your daily activity — but not your growth story.
 
-While GitHub's contribution graph shows daily activity, it's hard to see your cumulative growth over time. This service generates a dynamic growth graph that clearly displays your accumulated contributions and language statistics across years, perfect for showcasing your consistent effort on your profile. Only public repository contributions are included.
+This service generates a dynamic, cumulative growth graph that reveals how your contributions compound over time, perfect for showcasing your consistent effort on your profile. Only public repository contributions are included.
 
 [![GitHub Contribution Growth Graph](https://github-contribution-growth-graph.qkitzero.xyz/graph/contributions?user=qkitzero&v=2026-03-13)](https://github.com/qkitzero/github-contribution-growth-graph)
 [![GitHub Language Growth Graph](https://github-contribution-growth-graph.qkitzero.xyz/graph/languages?user=qkitzero&v=2026-03-13)](https://github.com/qkitzero/github-contribution-growth-graph)
+
+> ⭐ If this helps you tell your growth story, please consider starring the repo — it helps others discover it too.
+
+## Features
+
+- **Cumulative growth visualization** across multiple years — see how your contributions compound
+- **Language usage breakdown** over time, weighted by commit activity
+- **9 color themes** to match your profile style
+- **Dynamic SVG** — always up to date, no manual regeneration required
+
+> Unlike [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) which shows your *current* stats, this project visualizes your **growth trajectory** over time.
 
 ## Quick Start
 
@@ -119,3 +130,10 @@ Graph images are cached for up to 7 days. To force a refresh, append a version p
 ```
 
 Since the URL differs, CDNs and browser caches treat it as a new resource, bypassing the cached version.
+
+---
+
+<p align="center">
+  Built by <a href="https://github.com/qkitzero">qkitzero</a> ·
+  Also check out <a href="https://github.com/qkitzero/kage-bunshin">kage-bunshin</a> — AI agents for knowledge work
+</p>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This service generates a dynamic, cumulative growth graph that reveals how your 
 - **Cumulative growth visualization** across multiple years — see how your contributions compound
 - **Language usage breakdown** over time, weighted by commit activity
 - **9 color themes** to match your profile style
-- **Dynamic SVG** — always up to date, no manual regeneration required
+- **Dynamic PNG** — always up to date, no manual regeneration required
 
 > Unlike [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) which shows your *current* stats, this project visualizes your **growth trajectory** over time.
 


### PR DESCRIPTION
## Summary

Polish README to improve first impression and discoverability, preparing for awesome-list submissions. Closes #170.

## Changes

- **Value proposition rewritten** — contrast-driven hook ("daily activity — but not your growth story")
- **Features section added** before Quick Start (4 bullets)
- **Differentiation line** vs `github-readme-stats` (current stats vs growth trajectory)
- **Star CTA** surfaced right after the live demo graphs
- **Footer** linking to qkitzero and kage-bunshin

## Repo settings (applied separately via gh repo edit)

- New topics added: `svg`, `dynamic-badge`, `profile-readme`, `github-profile-readme`, `data-visualization`
- Homepage URL was considered (per issue #170) but deferred — the service root currently returns no landing page, so setting it would send visitors to an empty URL. Revisit once a landing page is implemented.

## Test plan

- [x] Preview README on GitHub and confirm rendering of new sections
- [x] Verify Star call-to-action is visible above the fold on typical screens
- [x] Confirm footer links (qkitzero, kage-bunshin) resolve correctly
- [x] Verify new topics are discoverable via topic search

🤖 Generated with [Claude Code](https://claude.com/claude-code)