### PR TITLE
Polish chart visuals with high-DPI rendering and modern styling

### DIFF
--- a/src/infrastructure/chart/chartjsGraphRenderer.ts
+++ b/src/infrastructure/chart/chartjsGraphRenderer.ts
@@ -1,4 +1,10 @@
-import { ChartConfiguration, ChartDataset } from 'chart.js';
+import {
+  ChartConfiguration,
+  ChartDataset,
+  Plugin,
+  ScriptableContext,
+  ScriptableScaleContext,
+} from 'chart.js';
 import { ChartJSNodeCanvas } from 'chartjs-node-canvas';
 import { GraphRenderer } from '../../application/graphRenderer';
 import {
@@ -11,11 +17,37 @@ import { Size } from '../../domain/graph/size';
 import { Theme } from '../../domain/graph/theme';
 import { AggregatedLanguages, Language, Languages } from '../../domain/language/language';
 
+const FONT_FAMILY =
+  "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif";
+
+type Gradient = { addColorStop(offset: number, color: string): void };
+type CanvasCtx = {
+  save(): void;
+  restore(): void;
+  fillStyle: string;
+  fillRect(x: number, y: number, w: number, h: number): void;
+  createLinearGradient(x0: number, y0: number, x1: number, y1: number): Gradient;
+};
+
+const CARD_PLUGIN: Plugin = {
+  id: 'gcgChartCard',
+  beforeDraw(chart) {
+    const ctx = chart.ctx as unknown as CanvasCtx;
+    const { chartArea } = chart;
+    if (!chartArea) return;
+    ctx.save();
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.02)';
+    ctx.fillRect(chartArea.left, chartArea.top, chartArea.width, chartArea.height);
+    ctx.restore();
+  },
+};
+
 export class ChartjsGraphRenderer implements GraphRenderer {
   private static readonly CHART_DEFAULTS = {
-    TENSION: 0.1,
+    TENSION: 0.35,
     POINT_RADIUS: 0,
-    BACKGROUND_ALPHA: '80',
+    BORDER_WIDTH: 2,
+    DEVICE_PIXEL_RATIO: 2,
   } as const;
 
   private createCanvas(size: Size, theme: Theme): ChartJSNodeCanvas {
@@ -26,6 +58,10 @@ export class ChartjsGraphRenderer implements GraphRenderer {
       chartCallback: (ChartJS) => {
         ChartJS.defaults.responsive = true;
         ChartJS.defaults.maintainAspectRatio = false;
+        ChartJS.defaults.devicePixelRatio = ChartjsGraphRenderer.CHART_DEFAULTS.DEVICE_PIXEL_RATIO;
+        ChartJS.defaults.font.family = FONT_FAMILY;
+        ChartJS.defaults.font.size = 12;
+        ChartJS.defaults.font.weight = 500;
       },
     });
   }
@@ -57,8 +93,8 @@ export class ChartjsGraphRenderer implements GraphRenderer {
     const chartConfiguration = this.createChartConfiguration(
       periods,
       datasets,
-      'GitHub Contribution Growth Graph',
       'Cumulative Contributions',
+      themeObj,
     );
 
     return await canvas.renderToBuffer(chartConfiguration);
@@ -82,8 +118,8 @@ export class ChartjsGraphRenderer implements GraphRenderer {
     const chartConfiguration = this.createChartConfiguration(
       periods,
       datasets,
-      'GitHub Language Growth Graph',
       'Cumulative Language Activity (weighted commits)',
+      themeObj,
     );
 
     return await canvas.renderToBuffer(chartConfiguration);
@@ -114,16 +150,7 @@ export class ChartjsGraphRenderer implements GraphRenderer {
       const color = theme.getColorForType(type);
       const cumulativeData = contributions.calculateCumulative(periodData, periods);
 
-      return {
-        label: type,
-        data: cumulativeData,
-        borderColor: color,
-        backgroundColor: `${color}${ChartjsGraphRenderer.CHART_DEFAULTS.BACKGROUND_ALPHA}`,
-        fill: true,
-        tension: ChartjsGraphRenderer.CHART_DEFAULTS.TENSION,
-        pointRadius: ChartjsGraphRenderer.CHART_DEFAULTS.POINT_RADIUS,
-        stack: 'contributions',
-      };
+      return this.buildDataset(type, cumulativeData, color, 'contributions');
     });
   }
 
@@ -138,46 +165,113 @@ export class ChartjsGraphRenderer implements GraphRenderer {
       const { color, data: periodData } = aggregated.get(langName)!;
       const cumulativeData = languages.calculateCumulative(periodData, periods);
 
-      return {
-        label: langName,
-        data: cumulativeData,
-        borderColor: color,
-        backgroundColor: `${color}${ChartjsGraphRenderer.CHART_DEFAULTS.BACKGROUND_ALPHA}`,
-        fill: true,
-        tension: ChartjsGraphRenderer.CHART_DEFAULTS.TENSION,
-        pointRadius: ChartjsGraphRenderer.CHART_DEFAULTS.POINT_RADIUS,
-        stack: 'languages',
-      };
+      return this.buildDataset(langName, cumulativeData, color, 'languages');
     });
+  }
+
+  private buildDataset(
+    label: string,
+    data: number[],
+    color: string,
+    stack: string,
+  ): ChartDataset<'line'> {
+    return {
+      label,
+      data,
+      borderColor: color,
+      backgroundColor: this.makeAreaGradient(color),
+      fill: true,
+      tension: ChartjsGraphRenderer.CHART_DEFAULTS.TENSION,
+      pointRadius: ChartjsGraphRenderer.CHART_DEFAULTS.POINT_RADIUS,
+      borderWidth: ChartjsGraphRenderer.CHART_DEFAULTS.BORDER_WIDTH,
+      borderJoinStyle: 'round',
+      borderCapStyle: 'round',
+      stack,
+    };
+  }
+
+  private makeAreaGradient(color: string) {
+    return (ctx: ScriptableContext<'line'>) => {
+      const c = ctx.chart.ctx as unknown as CanvasCtx;
+      const { chartArea } = ctx.chart;
+      if (!chartArea) return `${color}40`;
+      const grad = c.createLinearGradient(0, chartArea.top, 0, chartArea.bottom);
+      grad.addColorStop(0, `${color}B0`);
+      grad.addColorStop(1, `${color}10`);
+      return grad;
+    };
   }
 
   private createChartConfiguration(
     labels: string[],
     datasets: ChartDataset<'line'>[],
-    graphTitle: string,
     yAxisTitle: string,
+    theme: Theme,
   ): ChartConfiguration {
+    const gridColor = this.gridColor(theme);
+    const axisLabelColor = this.axisLabelColor(theme);
+
     return {
       type: 'line',
+      plugins: [CARD_PLUGIN],
       data: {
         labels,
         datasets,
       },
       options: {
+        layout: { padding: { right: 8, left: 4, top: 8, bottom: 4 } },
         scales: {
           x: {
             title: { display: false, text: 'Period' },
+            grid: { display: false },
+            border: { display: false },
+            ticks: {
+              autoSkip: true,
+              maxTicksLimit: 10,
+              maxRotation: 0,
+              color: axisLabelColor,
+            },
           },
           y: {
             title: { display: false, text: yAxisTitle },
             beginAtZero: true,
+            grid: {
+              color: (ctx: ScriptableScaleContext) =>
+                ctx.tick.value === 0 ? 'transparent' : gridColor,
+            },
+            border: { display: false },
+            ticks: { color: axisLabelColor },
           },
         },
         plugins: {
-          legend: { display: true, position: 'top' },
-          title: { display: true, text: graphTitle },
+          legend: {
+            display: true,
+            position: 'bottom',
+            align: 'end',
+            labels: {
+              usePointStyle: true,
+              pointStyle: 'circle',
+              boxWidth: 8,
+              boxHeight: 8,
+              padding: 12,
+              color: axisLabelColor,
+            },
+          },
+          title: { display: false },
         },
       },
     };
+  }
+
+  private gridColor(theme: Theme): string {
+    const bg = theme.backgroundColor;
+    if (bg === '#000000') return 'rgba(255, 255, 255, 0.08)';
+    return 'rgba(0, 0, 0, 0.08)';
+  }
+
+  private axisLabelColor(theme: Theme): string {
+    const bg = theme.backgroundColor;
+    if (bg === '#000000') return '#8b949e';
+    return '#656d76';
   }
 }


### PR DESCRIPTION
## Summary

Improves the look of contribution and language graphs without changing the rendering stack (still Chart.js + chartjs-node-canvas, still PNG).

### What changed
- **High-DPI output** — `devicePixelRatio: 2` so charts stay sharp on Retina/HiDPI displays (file size ~2x; cached for 7 days, so the impact is amortized)
- **Vertical gradient fills** — areas fade from 70% alpha at the top to 6% at the bottom, replacing the flat 50% alpha
- **System font stack** — `-apple-system, Segoe UI, Roboto, ...` instead of the canvas default
- **Smoother lines** — tension `0.1` → `0.35`, rounded line joins/caps, `borderWidth: 2`
- **Cleaner axes** — chart title hidden (README already has its own heading), x-axis grid removed, y-axis grid faded to 8% alpha, axis borders removed
- **Smarter x-axis labels** — `autoSkip` with `maxTicksLimit: 10`, no rotation
- **Restyled legend** — moved to bottom-right with circular point markers and muted text color
- **Theme-aware colors** — grid and label colors adapt to light vs `dark` background
- **Subtle card background** — 2% alpha plot-area fill (`CARD_PLUGIN`) for a faint card feel on transparent-background themes

No public API or query parameter changed. All existing endpoints and themes behave the same; only the rendered pixels look different.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` — all 91 tests pass
- [x] Smoke render across 4 themes (default/dark/light/purple), language graph (large), and empty data — all produce valid PNGs
- [ ] Visual review of the rendered output in a browser/README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)