### PR TITLE
docs: document the no-code playground in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,15 @@ This service generates a dynamic, cumulative growth graph that reveals how your 
 - **Language usage breakdown** over time, weighted by commit activity
 - **9 color themes** to match your profile style
 - **Dynamic PNG** — always up to date, no manual regeneration required
+- **No-code playground** — configure your graph visually and copy the snippet in one click
 
 > Unlike [github-readme-stats](https://github.com/anuraghazra/github-readme-stats) which shows your *current* stats, this project visualizes your **growth trajectory** over time.
 
 ## Quick Start
+
+### Playground
+
+Prefer not to hand-write parameters? Open the **[no-code Playground](https://github-contribution-growth-graph.qkitzero.xyz/)** to configure your graph visually, watch a live preview, and copy ready-to-paste Markdown, URL, or HTML in one click.
 
 ### Contribution Graph
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This service generates a dynamic, cumulative growth graph that reveals how your 
 
 ### Playground
 
-Prefer not to hand-write parameters? Open the **[no-code Playground](https://github-contribution-growth-graph.qkitzero.xyz/)** to configure your graph visually, watch a live preview, and copy ready-to-paste Markdown, URL, or HTML in one click.
+Prefer not to hand-write parameters? Open the **[no-code Playground](https://github-contribution-growth-graph.qkitzero.xyz/)** to configure your graph visually, watch a live preview, and copy ready-to-paste Markdown, URL, or HTML snippets in one click.
 
 ### Contribution Graph
 


### PR DESCRIPTION
## Summary

Document the no-code Playground (added in #178) in the README so users can discover the visual generator instead of hand-assembling URL parameters.

Closes #181

## Changes

- Add a **Playground** subsection at the top of **Quick Start**, linking to the hosted page.
- Add a **No-code playground** entry to the **Features** list.

## Notes

- The manual URL-parameter docs are kept; the Playground is presented as the quickest option, not a replacement.
- The link points to the deployed root; it becomes live once #178 is merged and deployed.